### PR TITLE
ci: Automatically release the project on commits to main

### DIFF
--- a/.github/workflows/build-documentation.yaml
+++ b/.github/workflows/build-documentation.yaml
@@ -22,7 +22,7 @@ jobs:
       run: |
         scripts/build-documentation.sh
 
-    - name: Commit documentation
+    - name: Publish documentation
       if: github.ref == 'refs/heads/main'
       uses: stefanzweifel/git-auto-commit-action@v4
       id: auto-commit

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -23,3 +23,7 @@ jobs:
 
     - name: Build
       run: exec ./scripts/build.sh
+
+    - name: Release
+      if: github.ref == 'refs/heads/main'
+      run: scripts/release.sh

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "scripts/changes"]
+	path = scripts/changes
+	url = git@github.com:jbmorley/changes.git

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+# Copyright (c) 2021 InSeven Limited
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+SCRIPTS_DIRECTORY="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+ROOT_DIRECTORY="${SCRIPTS_DIRECTORY}/.."
+CHANGES_SCRIPT="${ROOT_DIRECTORY}/changes"
+RELEASE_SCRIPT="${ROOT_DIRECTORY}/examples/gh-release.sh"
+
+"${CHANGES_SCRIPT}" --verbose release --skip-if-empty --push --command "\"${RELEASE_SCRIPT}\"" "\"$@\""


### PR DESCRIPTION
This change includes a drive-by rename to the the step that publishes documentation.