### PR TITLE
feat: Add `safeNavigationLink` view modifier

### DIFF
--- a/Sources/Interact/View Modifiers/SafeNavigationLink.swift
+++ b/Sources/Interact/View Modifiers/SafeNavigationLink.swift
@@ -1,0 +1,50 @@
+// Copyright (c) 2018-2023 InSeven Limited
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import SwiftUI
+
+
+@available(iOS 16, *)
+struct SafeNavigationLink<P: Hashable>: ViewModifier {
+
+    let value: P
+
+    public func body(content: Content) -> some View {
+#if os(iOS)
+        NavigationLink(value: value) {
+            content
+                .tag(value)
+        }
+#else
+        content
+            .tag(value)
+#endif
+    }
+
+}
+
+extension View {
+
+    @available(iOS 16, *)
+    public func safeNavigationLink<P: Hashable>(_ value: P) -> some View {
+        return modifier(SafeNavigationLink(value: value))
+    }
+
+}


### PR DESCRIPTION
Work-around for the differences (bugs) between macOS and iOS `NavigationSplitView` behavior. Specifically, using a `NavigationLink` on macOS breaks default sidebar section selection, but we loose disclosure indicators if we don't use it on iOS. 🤦🏻‍♂️