### PR TITLE
fix: Export a Diligence license if the package is available

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.3
+// swift-tools-version:5.7
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
@@ -6,8 +6,8 @@ import PackageDescription
 let package = Package(
     name: "Interact",
     platforms: [
-        .macOS(.v11),
-        .iOS(.v14)
+        .macOS(.v12),
+        .iOS(.v15)
     ],
     products: [
         // Products define the executables and libraries a package produces, and make them visible to other packages.

--- a/Sources/Interact/Package.swift
+++ b/Sources/Interact/Package.swift
@@ -30,3 +30,16 @@ public struct Package {
     }
 
 }
+
+#if canImport(Diligence)
+import Diligence
+
+extension Package {
+
+    public static var license: License {
+        return License(name, author: author, url: licenseURL)
+    }
+
+}
+
+#endif

--- a/Sources/Interact/Utilities/Application.swift
+++ b/Sources/Interact/Utilities/Application.swift
@@ -18,12 +18,17 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-import ServiceManagement
 import SwiftUI
+
+#if canImport(ServiceManagement)
+import ServiceManagement
+#endif
 
 public class Application: ObservableObject {
 
     public static var shared = Application()
+
+#if canImport(ServiceManagement)
 
     @available(macOS 13.0, *)
     @available(iOS, unavailable)
@@ -50,6 +55,8 @@ public class Application: ObservableObject {
             }
         }
     }
+
+#endif
 
     public static func open(_ url: URL) {
 #if os(macOS)


### PR DESCRIPTION
This includes some drive-by fixes when compiling against earlier versions of iOS.