### PR TITLE
fix: Update minimum version of Licensable to 0.0.13

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -15,7 +15,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0"),
-        .package(url: "https://github.com/inseven/licensable", from: "0.0.11"),
+        .package(url: "https://github.com/inseven/licensable", from: "0.0.13"),
     ],
     targets: [
         .target(


### PR DESCRIPTION
This addresses an issue where Licensable renamed the `License` constructor parameters.