### PR TITLE
feat: Add `.prompt` like view modifier for presenting alerts

### DIFF
--- a/Sources/Interact/Model/Prompt.swift
+++ b/Sources/Interact/Model/Prompt.swift
@@ -20,27 +20,27 @@
 
 import SwiftUI
 
-public protocol PromptProtocol {
-
+public protocol Promptable {
+    
     associatedtype Actions: View
     associatedtype Message: View
-
+    
     var title: String { get }
     var actions: Actions { get }
     var message: Message { get }
-
+    
 }
 
-public struct Prompt<Actions: View, Message: View>: PromptProtocol {
-
+public struct Prompt<Actions: View, Message: View>: Promptable {
+    
     public let title: String
     public let actions: Actions
     public let message: Message
-
+    
     public init(_ title: String, @ViewBuilder actions: () -> Actions, @ViewBuilder message: () -> Message) {
         self.title = title
         self.actions = actions()
         self.message = message()
     }
-
+    
 }

--- a/Sources/Interact/Model/Prompt.swift
+++ b/Sources/Interact/Model/Prompt.swift
@@ -1,0 +1,46 @@
+// Copyright (c) 2018-2026 Jason Morley
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import SwiftUI
+
+public protocol PromptProtocol {
+
+    associatedtype Actions: View
+    associatedtype Message: View
+
+    var title: String { get }
+    var actions: Actions { get }
+    var message: Message { get }
+
+}
+
+public struct Prompt<Actions: View, Message: View>: PromptProtocol {
+
+    public let title: String
+    public let actions: Actions
+    public let message: Message
+
+    public init(_ title: String, @ViewBuilder actions: () -> Actions, @ViewBuilder message: () -> Message) {
+        self.title = title
+        self.actions = actions()
+        self.message = message()
+    }
+
+}

--- a/Sources/Interact/Modifiers/PromptModifier.swift
+++ b/Sources/Interact/Modifiers/PromptModifier.swift
@@ -20,7 +20,7 @@
 
 import SwiftUI
 
-struct PromptModifier<T: Identifiable, A: PromptProtocol>: ViewModifier {
+struct PromptModifier<T: Identifiable, A: Promptable>: ViewModifier {
 
     @Binding var item: T?
 
@@ -40,8 +40,8 @@ struct PromptModifier<T: Identifiable, A: PromptProtocol>: ViewModifier {
 
 public extension View {
 
-    func prompt<T: Identifiable, A: PromptProtocol>(item: Binding<T?>,
-                                                    content: @escaping (T) -> A) -> some View {
+    func prompt<T: Identifiable, A: Promptable>(item: Binding<T?>,
+                                                content: @escaping (T) -> A) -> some View {
         self.modifier(PromptModifier(item: item, content: content))
     }
 

--- a/Sources/Interact/Modifiers/PromptModifier.swift
+++ b/Sources/Interact/Modifiers/PromptModifier.swift
@@ -1,0 +1,48 @@
+// Copyright (c) 2018-2026 Jason Morley
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import SwiftUI
+
+struct PromptModifier<T: Identifiable, A: PromptProtocol>: ViewModifier {
+
+    @Binding var item: T?
+
+    let content: (T) -> A
+
+    func body(content: Content) -> some View {
+        let alertContent = item.map(self.content)
+        return content.alert(alertContent?.title ?? "",
+                             isPresented: $item.bool(),
+                             presenting: alertContent) { alertContent in
+            alertContent.actions
+        } message: { alertContent in
+            alertContent.message
+        }
+    }
+}
+
+public extension View {
+
+    func prompt<T: Identifiable, A: PromptProtocol>(item: Binding<T?>,
+                                                    content: @escaping (T) -> A) -> some View {
+        self.modifier(PromptModifier(item: item, content: content))
+    }
+
+}


### PR DESCRIPTION
This is modeled after the built-in `.sheet` modifier.